### PR TITLE
avatar.jpg endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Also check out our [Figma Plugin](https://github.com/maximedegreve/TinyFaces-Fig
 
 **Query**
 - `quality` : Filters the result(s) to lower or higher quality images by using a value from 0 to 10.
-- `gender` : Possible values for gender can be found in [Gender.swift](/master/Sources/App/Models/Gender.swift)
+- `gender` : Possible values for gender can be found in [Gender.swift](/Sources/App/Models/Gender.swift)
 - `limit` : To limit how many results you get back by using a value of 50 or lower. Only works with the data endpoint. When mixed with gender this could return less than n results.
 
 ## 🎒 Before building (dependencies)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,19 @@ Free stock avatars for everyone
 
 Tiny Faces is a free crowd-sourced avatar gallery to use in your personal or commercial projects
 
-Also check out our [TinyFaces Sketch Plugin](https://github.com/maximedegreve/TinyFaces-Sketch-Plugin)
+Also check out our [Figma Plugin](https://github.com/maximedegreve/TinyFaces-Figma-Plugin) and [Sketch Plugin](https://github.com/maximedegreve/TinyFaces-Sketch-Plugin)
+
+## 🦾 API
+
+There are currently 2 endpoints.
+
+**GET**: https://tinyfac.es/api/data?limit=50&gender=female&quality=0
+**GET**: https://tinyfac.es/api/avatar.jpg&gender=female&quality=0
+
+**Query**
+- `quality` : Filters the result(s) to lower or higher quality images by using a value from 0 to 10.
+- `gender` : Possible values for gender can be found in [Gender.swift](/master/Sources/App/Models/Gender.swift)
+- `limit` : To limit how many results you get back by using a value of 50 or lower. Only works with the data endpoint. When mixed with gender this could return less than n results.
 
 ## 🎒 Before building (dependencies)
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,9 @@ Also check out our [Figma Plugin](https://github.com/maximedegreve/TinyFaces-Fig
 
 ## 🦾 API
 
-There are currently 2 endpoints.
-
-**GET**: https://tinyfac.es/api/data?limit=50&gender=female&quality=0
-**GET**: https://tinyfac.es/api/avatar.jpg&gender=female&quality=0
+**Endpoints**
+- `GET`: https://tinyfac.es/api/data?limit=50&gender=female&quality=0
+- `GET`: https://tinyfac.es/api/avatar.jpg&gender=female&quality=0
 
 **Query**
 - `quality` : Filters the result(s) to lower or higher quality images by using a value from 0 to 10.

--- a/Sources/App/Controllers API/AvatarController.swift
+++ b/Sources/App/Controllers API/AvatarController.swift
@@ -1,6 +1,5 @@
 import Vapor
 import Fluent
-import Crypto
 
 final class AvatarController {
 

--- a/Sources/App/Controllers API/AvatarController.swift
+++ b/Sources/App/Controllers API/AvatarController.swift
@@ -1,0 +1,39 @@
+import Vapor
+import Fluent
+import Crypto
+
+final class AvatarController {
+
+    func index(request: Request) throws -> EventLoopFuture<Response> {
+
+        struct RequestData: Content {
+            var quality: Int?
+            var gender: Gender?
+        }
+        
+        let data = try request.query.decode(RequestData.self)
+        
+        return randomAvatar(request: request, gender: data.gender, quality: data.quality ?? 0).flatMap { optionalAvatar in
+            
+            guard let avatar = optionalAvatar else {
+                return request.eventLoop.makeFailedFuture(Abort(.notFound, reason: "Not avatar found for your query."))
+            }
+
+            return request.eventLoop.future(request.redirect(to: avatar.url))
+        }
+
+    }
+    
+    func randomAvatar(request: Request, gender: Gender?, quality: Int) -> EventLoopFuture<Avatar?> {
+
+        let baseQuery = Avatar.query(on: request.db).with(\.$source).filter(\.$quality >= quality).filter(\.$approved == true)
+
+        if let gender = gender {
+            baseQuery.filter(\.$gender == gender)
+        }
+
+        return baseQuery.sort(.sql(raw: "rand()")).first()
+
+    }
+
+}

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -9,6 +9,7 @@ func routes(_ app: Application) throws {
     let addController = AddController()
     let facebookController = FacebookController()
     let statusController = StatusController()
+    let avatarController = AvatarController()
 
     // MARK: Pages
     app.get(use: homeController.index)
@@ -21,6 +22,6 @@ func routes(_ app: Application) throws {
 
     // MARK: API
     app.get("api", "data", use: dataController.index)
-    app.get("api", "user", use: dataController.index) // Legacy Endpoint
+    app.get("api", "avatar.jpg", use: avatarController.index)
 
 }


### PR DESCRIPTION
Adds a new way of fetching an avatar by using the `tinyfac.es/data/avatar.jpg` endpoint. This is useful for direct linking instead of having to make API calls first.